### PR TITLE
Fix a copy-paste error on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@ sayHiToAnimal animal =
                 <ul>
                     <li>Testing via <code>derw test</code></li>
                     <li>Packages via <code>derw install</code></li>
-                    <li>Packages via <code>derw format</code></li>
+                    <li>Formatting via <code>derw format</code></li>
                     <li>Html via <code>coed</code></li>
                     <li>Do-notation for effects</li>
                     <li>Hydration</li>


### PR DESCRIPTION
I've only guessed at the word "Formatting", maybe you intended for "Formats" or something like that?

Sorry for the EOF `\n`, GitHub UI kinda added that on its own.